### PR TITLE
Add config for auto place tiles

### DIFF
--- a/src/main/java/com/tileman/TilemanModeConfig.java
+++ b/src/main/java/com/tileman/TilemanModeConfig.java
@@ -78,4 +78,16 @@ public interface TilemanModeConfig extends Config
 	{
 		return 20;
 	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "automarkTiles",
+			name = "Auto-mark tiles",
+			description = "Automatically mark tiles as you walk.",
+			warning = "Will sometimes miss marking a tile"
+	)
+	default boolean automarkTiles()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/tileman/TilemanModeOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeOverlay.java
@@ -73,7 +73,7 @@ public class TilemanModeOverlay extends Overlay
 			return null;
 		}
 
-		plugin.markTile(playerPosLocal, false);
+		plugin.handleMovement(playerPosLocal);
 
 		final Collection<WorldPoint> points = plugin.getPoints();
 		for (final WorldPoint point : points)

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -190,7 +190,7 @@ public class TilemanModePlugin extends Plugin {
         if (target == null) {
             return;
         }
-        markTile(target.getLocalLocation(), true);
+        handleMenuOption(target.getLocalLocation(), event.getMenuOption().equals(MARK));
     }
 
     @Subscribe
@@ -245,6 +245,60 @@ public class TilemanModePlugin extends Plugin {
 
     int getRemainingTiles() {
         return remainingTiles;
+    }
+
+    void handleMenuOption(LocalPoint selectedPoint, boolean markedValue) {
+        if (selectedPoint == null) {
+            return;
+        }
+        updateTileMark(selectedPoint, markedValue);
+    }
+
+    void handleMovement(LocalPoint currentPlayerPoint) {
+        if (currentPlayerPoint == null || !config.automarkTiles() || client.isInInstancedRegion()) {
+            return;
+        }
+
+        // Mark the tile they walked to
+        updateTileMark(currentPlayerPoint, true);
+
+        // If player moves 2 tiles in a straight line, fill in the middle tile
+        // TODO Fill path between last point and current point. This will fix missing tiles that occur when you lag
+        // TODO   and rendered frames are skipped. See if RL has an api that mimic's OSRS's pathing. If so, use that to
+        // TODO   set all tiles between current tile and lastTile as marked
+        if (lastTile != null
+                && (lastTile.distanceTo(currentPlayerPoint) == 256 || lastTile.distanceTo(currentPlayerPoint) == 362)) {
+            int xDiff = lastTile.getX() - currentPlayerPoint.getX();
+            int yDiff = lastTile.getY() - currentPlayerPoint.getY();
+            int yModifier = yDiff / 2;
+            int xModifier = xDiff / 2;
+
+            updateTileMark(new LocalPoint(currentPlayerPoint.getX() + xModifier, currentPlayerPoint.getY() + yModifier), true);
+        }
+        lastTile = currentPlayerPoint;
+    }
+
+    void updateTileMark(LocalPoint localPoint, boolean markedValue) {
+        WorldPoint worldPoint = WorldPoint.fromLocalInstance(client, localPoint);
+
+        int regionId = worldPoint.getRegionID();
+        GroundMarkerPoint point = new GroundMarkerPoint(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane());
+        log.debug("Updating point: {} - {}", point, worldPoint);
+
+        List<GroundMarkerPoint> groundMarkerPoints = new ArrayList<>(getPoints(regionId));
+
+        if(markedValue) {
+            // Try add tile
+            if(!groundMarkerPoints.contains(point) && remainingTiles > 0) {
+                groundMarkerPoints.add(point);
+            }
+        } else {
+            // Try remove tile
+            groundMarkerPoints.remove(point);
+        }
+
+        savePoints(regionId, groundMarkerPoints);
+        loadPoints();
     }
 
     void markTile(LocalPoint localPoint, boolean menuOption) {

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -255,7 +255,10 @@ public class TilemanModePlugin extends Plugin {
     }
 
     void handleMovement(LocalPoint currentPlayerPoint) {
-        if (currentPlayerPoint == null || !config.automarkTiles() || client.isInInstancedRegion()) {
+        if (currentPlayerPoint == null ||
+            !config.automarkTiles() ||
+            (lastTile != null && lastTile.distanceTo(currentPlayerPoint) == 0)
+            || client.isInInstancedRegion()) {
             return;
         }
 

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -300,43 +300,4 @@ public class TilemanModePlugin extends Plugin {
         savePoints(regionId, groundMarkerPoints);
         loadPoints();
     }
-
-    void markTile(LocalPoint localPoint, boolean menuOption) {
-        if (localPoint == null || client.isInInstancedRegion() || (lastTile != null && lastTile.distanceTo(localPoint) == 0)) {
-            return;
-        }
-
-        // If player moves 2 tiles in a straight line, fill in the middle tile
-        if (!menuOption && lastTile != null
-                && (lastTile.distanceTo(localPoint) == 256 || lastTile.distanceTo(localPoint) == 362)) {
-            int xDiff = lastTile.getX() - localPoint.getX();
-            int yDiff = lastTile.getY() - localPoint.getY();
-            int yModifier = yDiff / 2;
-            int xModifier = xDiff / 2;
-
-            markTile(new LocalPoint(localPoint.getX() + xModifier, localPoint.getY() + yModifier), false);
-        }
-        lastTile = localPoint;
-
-        WorldPoint worldPoint = WorldPoint.fromLocalInstance(client, localPoint);
-
-        int regionId = worldPoint.getRegionID();
-        GroundMarkerPoint point = new GroundMarkerPoint(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane());
-        log.debug("Updating point: {} - {}", point, worldPoint);
-
-        List<GroundMarkerPoint> groundMarkerPoints = new ArrayList<>(getPoints(regionId));
-        if (groundMarkerPoints.contains(point)) {
-            if (menuOption) {
-                groundMarkerPoints.remove(point);
-            } else {
-                return;
-            }
-        } else if (remainingTiles > 0) {
-            groundMarkerPoints.add(point);
-        }
-
-        savePoints(regionId, groundMarkerPoints);
-
-        loadPoints();
-    }
 }


### PR DESCRIPTION
Adds a configuration for toggling auto-marking tiles.

I also refactored markTile. I split out the logic for handling marking during movement vs from the option menu into two functions: `handleMenuOption` and `handleMovement`. I also created a function `updateTileMark` which just handles marking/unmarking a single tile. `updateTileMark` takes an explicit mark/unmark boolean param and will try to add/remove the tile based on that. I did this to try to fix some weirdness that occured when both the groundMarker and tilemanMode plugins are on, but it didn't fully fix the issue.