### PR TITLE
Refactor marking trigger

### DIFF
--- a/src/main/java/com/tileman/TileInfoOverlay.java
+++ b/src/main/java/com/tileman/TileInfoOverlay.java
@@ -31,6 +31,7 @@ import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.LineComponent;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import java.awt.*;
@@ -51,25 +52,37 @@ class TileInfoOverlay extends OverlayPanel {
         this.config = config;
         setPosition(OverlayPosition.TOP_LEFT);
         setPriority(OverlayPriority.MED);
+//        setPreferredSize(new Dimension(250, 0));
         getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Tileman Mode overlay"));
     }
 
     @Override
     public Dimension render(Graphics2D graphics) {
-        int unspentTiles = plugin.getRemainingTiles();
+        String unspentTiles = String.valueOf(plugin.getRemainingTiles());
+        String unlockedTiles = String.valueOf(plugin.getTotalTiles());
+        int xpTowardsNextTile = Integer.parseInt(StringUtils.right(Long.toString(client.getOverallExperience()), 3));
+        String xpUntilNextTile = String.valueOf(1000 - xpTowardsNextTile);
 
         panelComponent.getChildren().add(LineComponent.builder()
                 .left("Available Tiles:")
                 .leftColor(getTextColor())
-                .right(String.valueOf(unspentTiles))
+                .right(unspentTiles)
                 .rightColor(getTextColor())
                 .build());
 
         panelComponent.getChildren().add(LineComponent.builder()
-                .left("Tiles Unlocked:")
-                .right(String.valueOf(plugin.getTotalTiles()))
+                .left("XP Until Next Tile:")
+                .right(xpUntilNextTile)
                 .build());
 
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Tiles Unlocked:")
+                .right(unlockedTiles)
+                .build());
+
+        panelComponent.setPreferredSize(new Dimension(
+                110 + graphics.getFontMetrics().stringWidth(unlockedTiles),
+                0));
 
         return super.render(graphics);
     }

--- a/src/main/java/com/tileman/TilemanModeConfig.java
+++ b/src/main/java/com/tileman/TilemanModeConfig.java
@@ -83,8 +83,7 @@ public interface TilemanModeConfig extends Config
 	@ConfigItem(
 			keyName = "automarkTiles",
 			name = "Auto-mark tiles",
-			description = "Automatically mark tiles as you walk.",
-			warning = "Will sometimes miss marking a tile"
+			description = "Automatically mark tiles as you walk."
 	)
 	default boolean automarkTiles()
 	{

--- a/src/main/java/com/tileman/TilemanModeOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeOverlay.java
@@ -60,21 +60,6 @@ public class TilemanModeOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-
-		final WorldPoint playerPos = client.getLocalPlayer().getWorldLocation();
-		if (playerPos == null)
-		{
-			return null;
-		}
-
-		final LocalPoint playerPosLocal = LocalPoint.fromWorld(client, playerPos);
-		if (playerPosLocal == null)
-		{
-			return null;
-		}
-
-		plugin.handleMovement(playerPosLocal);
-
 		final Collection<WorldPoint> points = plugin.getPoints();
 		for (final WorldPoint point : points)
 		{


### PR DESCRIPTION
-Info box now updates every tick rather than after changing a tile
-Checks for tile change every tick now rather than every frame
-Reorganised methods in Plugin class
-Added XP Until Next Tile to Overlay
-Removed automark toggle warning
-Refined logic for updating infobox, now only called when:
   -Earned a new tile 
   -Config settings changed (which can affect counter)
   -Plugin loads
   -Player moves

![image](https://user-images.githubusercontent.com/32102255/94338359-7c886d80-ffe9-11ea-8154-b45789cbc2bc.png)
