### PR TITLE
Multiple Bug Fixes

### DIFF
--- a/src/main/java/com/tileman/TileInfoOverlay.java
+++ b/src/main/java/com/tileman/TileInfoOverlay.java
@@ -59,8 +59,7 @@ class TileInfoOverlay extends OverlayPanel {
     public Dimension render(Graphics2D graphics) {
         String unspentTiles = String.valueOf(plugin.getRemainingTiles());
         String unlockedTiles = String.valueOf(plugin.getTotalTiles());
-        int xpTowardsNextTile = Integer.parseInt(StringUtils.right(Long.toString(client.getOverallExperience()), 3));
-        String xpUntilNextTile = String.valueOf(1000 - xpTowardsNextTile);
+        String xpUntilNextTile = String.valueOf(plugin.getXpUntilNextTile());
 
         panelComponent.getChildren().add(LineComponent.builder()
                 .left("Available Tiles:")

--- a/src/main/java/com/tileman/TilemanModeConfig.java
+++ b/src/main/java/com/tileman/TilemanModeConfig.java
@@ -107,6 +107,7 @@ public interface TilemanModeConfig extends Config
 		keyName = "enableCustomGameMode",
 		name = "Enable Custom Game Mode",
 		description = "Settings below will override Game Mode defaults",
+		section = customGameModeSection,
 		position = 1
 	)
 	default boolean enableCustomGameMode()

--- a/src/main/java/com/tileman/TilemanModeConfigEvaluator.java
+++ b/src/main/java/com/tileman/TilemanModeConfigEvaluator.java
@@ -99,7 +99,7 @@ class TilemanModeConfigEvaluator implements TilemanModeConfig {
         if(config.enableCustomGameMode()) {
             return config.excludeExp();
         } else {
-            return true;
+            return false;
         }
     }
 


### PR DESCRIPTION
- Moved xpUntilNextTile into Plugin class
- Moved enable customGameMode back to the Custom Game Mode section
- Fixed excludeExp config default in ConfigEval
- Updated mark/unmark option strings
- Fixed updateTileCounter being called every game tick
    - lastTile was not being updated by handleMove when automark was off. Moved lastTile update out of handleMove and into onGameTickUpdate
- Attempt to mark current tile when first logging in or toggling on automarktile
- Unset last tile on logout
- Updated plugin only use tilemanMode config group. No more using groundMarkers data
- remove check preventing Tileinfo from being updating when no tiles are places
- Fix updateRemainingTiles to include totalLevel if enabled when excludeExp is enabled