### PR TITLE
Fix menu entry instantiation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.36.2'
+def runeLiteVersion = '1.8.8'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -153,19 +153,16 @@ public class TilemanModePlugin extends Plugin {
                 return;
             }
 
-            MenuEntry[] menuEntries = client.getMenuEntries();
-            menuEntries = Arrays.copyOf(menuEntries, menuEntries.length + 1);
-            MenuEntry menuEntry = menuEntries[menuEntries.length - 1] = new MenuEntry();
 
             final WorldPoint worldPoint = WorldPoint.fromLocalInstance(client, selectedSceneTile.getLocalLocation());
             final int regionId = worldPoint.getRegionID();
             final TilemanModeTile point = new TilemanModeTile(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane());
 
-            menuEntry.setOption(getTiles(regionId).contains(point) ? UNMARK : MARK);
-            menuEntry.setTarget(event.getTarget());
-            menuEntry.setType(MenuAction.RUNELITE.getId());
+            client.createMenuEntry(-1)
+                    .setOption(getTiles(regionId).contains(point) ? UNMARK : MARK)
+                    .setTarget(event.getTarget())
+                    .setType(MenuAction.RUNELITE);
 
-            client.setMenuEntries(menuEntries);
         }
     }
 


### PR DESCRIPTION
Tileman Mode plugin is crashing and thus disappears from the Plugin hub. This is due to MenuEntry being changed to an interface and no longer being instantiatable

This MR updates menu entry code to use new MenuEntry creation API, which should fix the crash and restore the plugin to Runelite. Also updates the runeliteVersion