### PR TITLE
Performance improvements for late game with large amount of tile unlocks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.8'
+def runeLiteVersion = '1.8.15.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/tileman/TilemanModeConfig.java
+++ b/src/main/java/com/tileman/TilemanModeConfig.java
@@ -202,7 +202,7 @@ public interface TilemanModeConfig extends Config {
     }
 
     @Range(
-            min = 500
+            min = 1
     )
     @ConfigItem(
             keyName = "expPerTile",

--- a/src/main/java/com/tileman/TilemanModeConfig.java
+++ b/src/main/java/com/tileman/TilemanModeConfig.java
@@ -202,7 +202,7 @@ public interface TilemanModeConfig extends Config {
     }
 
     @Range(
-            min = 1
+            min = 500
     )
     @ConfigItem(
             keyName = "expPerTile",

--- a/src/main/java/com/tileman/TilemanModeMinimapOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeMinimapOverlay.java
@@ -34,7 +34,10 @@ import net.runelite.client.ui.overlay.*;
 
 import javax.inject.Inject;
 import java.awt.*;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 class TilemanModeMinimapOverlay extends Overlay
 {
@@ -45,6 +48,8 @@ class TilemanModeMinimapOverlay extends Overlay
 	private final Client client;
 	private final TilemanModeConfig config;
 	private final TilemanModePlugin plugin;
+
+	private List<WorldPoint> worldPointBuffer = new ArrayList<>(250);
 
 	@Inject
 	private TilemanModeMinimapOverlay(Client client, TilemanModeConfig config, TilemanModePlugin plugin)
@@ -65,22 +70,30 @@ class TilemanModeMinimapOverlay extends Overlay
 			return null;
 		}
 
-		final Collection<WorldPoint> points = plugin.getPoints();
-		for (final WorldPoint point : points)
-		{
-			WorldPoint worldPoint = point;
-			if (worldPoint.getPlane() != client.getPlane())
-			{
-				continue;
-			}
+		Color color = getTileColor();
+		int[] loadedRegions = client.getMapRegions();
+		Map<Integer, List<TilemanModeTile>> tilesByRegion = plugin.getPointsByRegion();
 
-			drawOnMinimap(graphics, worldPoint);
+		for (Integer region : loadedRegions)
+		{
+			List<TilemanModeTile> tiles = tilesByRegion.get(region);
+			worldPointBuffer.clear();
+			TilemanModePlugin.translateTilesToWorldPoints(client, tiles, worldPointBuffer);
+
+			for (final WorldPoint point : worldPointBuffer)
+			{
+				if (point.getPlane() != client.getPlane())
+				{
+					continue;
+				}
+				drawOnMinimap(graphics, point, color);
+			}
 		}
 
 		return null;
 	}
 
-	private void drawOnMinimap(Graphics2D graphics, WorldPoint point)
+	private void drawOnMinimap(Graphics2D graphics, WorldPoint point, Color color)
 	{
 		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
 
@@ -101,7 +114,7 @@ class TilemanModeMinimapOverlay extends Overlay
 			return;
 		}
 
-		OverlayUtil.renderMinimapRect(client, graphics, posOnMinimap, TILE_WIDTH, TILE_HEIGHT, getTileColor());
+		OverlayUtil.renderMinimapRect(client, graphics, posOnMinimap, TILE_WIDTH, TILE_HEIGHT, color);
 	}
 
 	private Color getTileColor() {

--- a/src/main/java/com/tileman/TilemanModeMinimapOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeMinimapOverlay.java
@@ -35,7 +35,6 @@ import net.runelite.client.ui.overlay.*;
 import javax.inject.Inject;
 import java.awt.*;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -72,7 +71,7 @@ class TilemanModeMinimapOverlay extends Overlay
 
 		Color color = getTileColor();
 		int[] loadedRegions = client.getMapRegions();
-		Map<Integer, List<TilemanModeTile>> tilesByRegion = plugin.getPointsByRegion();
+		Map<Integer, List<TilemanModeTile>> tilesByRegion = plugin.getTilesByRegion();
 
 		for (Integer region : loadedRegions)
 		{

--- a/src/main/java/com/tileman/TilemanModeOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeOverlay.java
@@ -34,7 +34,9 @@ import net.runelite.client.ui.overlay.*;
 
 import javax.inject.Inject;
 import java.awt.*;
-import java.util.Collection;
+import java.util.*;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class TilemanModeOverlay extends Overlay
 {
@@ -42,6 +44,7 @@ public class TilemanModeOverlay extends Overlay
 
 	private final Client client;
 	private final TilemanModePlugin plugin;
+	private List<WorldPoint> worldPointBuffer = new ArrayList<>(250);
 
 	@Inject
 	private TilemanModeConfig config;
@@ -60,21 +63,32 @@ public class TilemanModeOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		final Collection<WorldPoint> points = plugin.getPoints();
-		for (final WorldPoint point : points)
-		{
-			if (point.getPlane() != client.getPlane())
-			{
-				continue;
-			}
+		Color color = getTileColor();
+		int[] loadedRegions = client.getMapRegions();
+		Map<Integer, List<TilemanModeTile>> tilesByRegion = plugin.getPointsByRegion();
 
-			drawTile(graphics, point);
+		for (int region : loadedRegions)
+		{
+			List<TilemanModeTile> tiles = tilesByRegion.get(region);
+			worldPointBuffer.clear();
+			TilemanModePlugin.translateTilesToWorldPoints(client, tiles, worldPointBuffer);
+
+			for (final WorldPoint point : worldPointBuffer)
+			{
+				if (point.getPlane() != client.getPlane())
+				{
+					continue;
+				}
+
+				drawTile(graphics, point, color);
+			}
 		}
+
 
 		return null;
 	}
 
-	private void drawTile(Graphics2D graphics, WorldPoint point)
+	private void drawTile(Graphics2D graphics, WorldPoint point, Color color)
 	{
 		WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
 
@@ -95,7 +109,7 @@ public class TilemanModeOverlay extends Overlay
 			return;
 		}
 
-		OverlayUtil.renderPolygon(graphics, poly, getTileColor());
+		OverlayUtil.renderPolygon(graphics, poly, color);
 	}
 
 	private Color getTileColor() {

--- a/src/main/java/com/tileman/TilemanModeOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeOverlay.java
@@ -36,7 +36,6 @@ import javax.inject.Inject;
 import java.awt.*;
 import java.util.*;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class TilemanModeOverlay extends Overlay
 {
@@ -65,7 +64,7 @@ public class TilemanModeOverlay extends Overlay
 	{
 		Color color = getTileColor();
 		int[] loadedRegions = client.getMapRegions();
-		Map<Integer, List<TilemanModeTile>> tilesByRegion = plugin.getPointsByRegion();
+		Map<Integer, List<TilemanModeTile>> tilesByRegion = plugin.getTilesByRegion();
 
 		for (int region : loadedRegions)
 		{

--- a/src/main/java/com/tileman/TilemanModeWorldMapOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeWorldMapOverlay.java
@@ -28,6 +28,7 @@
 package com.tileman;
 
 import java.awt.*;
+import java.util.List;
 import javax.inject.Inject;
 
 import net.runelite.api.Client;
@@ -97,7 +98,11 @@ class TilemanModeWorldMapOverlay extends Overlay {
         for (int x = xRegionMin; x < xRegionMax; x += REGION_SIZE) {
             for (int y = yRegionMin; y < yRegionMax; y += REGION_SIZE) {
                 int regionId = ((x >> 6) << 8) | (y >> 6);
-                for (final TilemanModeTile tile : plugin.getTiles(regionId)) {
+                List<TilemanModeTile> tiles = plugin.getTilesByRegion().get(regionId);
+                if (tiles == null) {
+                    continue;
+                }
+                for (final TilemanModeTile tile : tiles) {
                     if(tile.getZ() != client.getPlane()) {
                         continue;
                     }


### PR DESCRIPTION
Changes how tile data is handled to prefer keeping it in the RAM as opposed to loading it from disk constantly.
Has a big performance impact once you have thousands of tiles unlocked.

Spoof data attached for testing, just paste it into settings.properties to have thousands of fake tiles unlocked.
[spoof.txt](https://github.com/ConorLeckey/Tileman-Mode/files/8401293/spoof.txt)
