### PR TITLE
Fix incorrectly interpolated skipped tiles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.8'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -27,7 +27,7 @@ dependencies {
 
 group = 'com.tileman'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = '1.8'
+sourceCompatibility = '1.11'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -506,10 +506,10 @@ public class TilemanModePlugin extends Plugin {
         if (tileBesideFlagsArray.length == 0) {
             fillTile(new LocalPoint(lastTile.getX() + tileBesideXDiff / 2, lastTile.getY() + tileBesideYDiff / 2));
         } else if (containsAnyOf(fullBlock, tileBesideFlagsArray)) {
-            if (yModifier == 64) {
-                yModifier = 128;
-            } else if (xModifier == 64) {
-                xModifier = 128;
+            if (Math.abs(yModifier) == 64) {
+                yModifier *= 2;
+            } else if (Math.abs(xModifier) == 64) {
+                xModifier *= 2;
             }
             fillTile(new LocalPoint(lastTile.getX() + xModifier, lastTile.getY() + yModifier));
         } else if (containsAnyOf(allDirections, tileBesideFlagsArray)){


### PR DESCRIPTION
Skipped tiles when running instead of walking are currently incorrectly interpolated when doing L-shaped movement around an object. This fix allows the filled in tiles to be correct for all cardinal directions (both negative and positive delta x- and y-movement).

|Before|After|
|:------|:-----|
|![before](https://github.com/user-attachments/assets/63811be8-4ea6-44a5-b02c-edc0a31f262a)|![after](https://github.com/user-attachments/assets/cf2ede6a-af24-4530-ab21-5de9d8a9499b)|

<details>
<summary>Another example of current wrong behaviour</summary>

![image](https://github.com/user-attachments/assets/319895cd-50a4-43bc-a0bd-734a70b344cb)

</detail>