### PR TITLE
Fix latency at high tile counts.

### DIFF
--- a/src/main/java/com/tileman/TilemanModeMinimapOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeMinimapOverlay.java
@@ -65,7 +65,7 @@ class TilemanModeMinimapOverlay extends Overlay
 			return null;
 		}
 
-		final Collection<WorldPoint> points = plugin.getPoints();
+		final Collection<WorldPoint> points = plugin.getTilesToRender();
 		for (final WorldPoint point : points)
 		{
 			WorldPoint worldPoint = point;

--- a/src/main/java/com/tileman/TilemanModeOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeOverlay.java
@@ -60,7 +60,7 @@ public class TilemanModeOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		final Collection<WorldPoint> points = plugin.getPoints();
+		final Collection<WorldPoint> points = plugin.getTilesToRender();
 		for (final WorldPoint point : points)
 		{
 			if (point.getPlane() != client.getPlane())

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -219,8 +219,11 @@ public class TilemanModePlugin extends Plugin {
         overlayManager.add(minimapOverlay);
         overlayManager.add(worldMapOverlay);
         overlayManager.add(infoOverlay);
-        //updateTilesToRender();
-        //updateTileCountFromConfigs();
+
+        // update so we render if the plugin has just been freshly enabled.
+        updateTileCountFromConfigs();
+        updateTilesToRender();
+
         log.debug("startup");
         TilemanImportPanel panel = new TilemanImportPanel(this);
         NavigationButton navButton = NavigationButton.builder()

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -66,7 +66,7 @@ public class TilemanModePlugin extends Plugin {
     private static final String REGION_PREFIX = "region_";
 
     @Getter(AccessLevel.PACKAGE)
-    private final List<WorldPoint> points = new ArrayList<>();
+    private final List<WorldPoint> tilesToRender = new ArrayList<>();
 
     @Inject
     private Client client;
@@ -174,12 +174,15 @@ public class TilemanModePlugin extends Plugin {
 
     @Subscribe
     public void onGameStateChanged(GameStateChanged gameStateChanged) {
+
+        // Guard against doing anything until the player is actually logged in
         if (gameStateChanged.getGameState() != GameState.LOGGED_IN) {
             lastTile = null;
             return;
         }
-        loadPoints();
-        updateTileCounter();
+
+        updateTileCountFromConfigs();
+        updateTilesToRender();
         inHouse = false;
     }
 
@@ -192,7 +195,7 @@ public class TilemanModePlugin extends Plugin {
             handleWalkedToTile(playerPosLocal);
         }
         lastAutoTilesConfig = config.automarkTiles();
-        updateTileCounter();
+        updateTileCountFromConfigs();
     }
 
 
@@ -216,8 +219,8 @@ public class TilemanModePlugin extends Plugin {
         overlayManager.add(minimapOverlay);
         overlayManager.add(worldMapOverlay);
         overlayManager.add(infoOverlay);
-        loadPoints();
-        updateTileCounter();
+        //updateTilesToRender();
+        //updateTileCountFromConfigs();
         log.debug("startup");
         TilemanImportPanel panel = new TilemanImportPanel(this);
         NavigationButton navButton = NavigationButton.builder()
@@ -237,7 +240,7 @@ public class TilemanModePlugin extends Plugin {
         overlayManager.remove(minimapOverlay);
         overlayManager.remove(worldMapOverlay);
         overlayManager.remove(infoOverlay);
-        points.clear();
+        tilesToRender.clear();
     }
 
     private void autoMark() {
@@ -251,8 +254,6 @@ public class TilemanModePlugin extends Plugin {
             return;
         }
 
-        long currentTotalXp = client.getOverallExperience();
-
         // If we have no last tile, we probably just spawned in, so make sure we walk on our current tile
         if ((lastTile == null
                 || (lastTile.distanceTo(playerPosLocal) != 0 && lastPlane == playerPos.getPlane())
@@ -261,13 +262,17 @@ public class TilemanModePlugin extends Plugin {
             handleWalkedToTile(playerPosLocal);
             lastTile = playerPosLocal;
             lastPlane = client.getPlane();
-            updateTileCounter();
             log.debug("player moved");
             log.debug("last tile={}  distance={}", lastTile, lastTile == null ? "null" : lastTile.distanceTo(playerPosLocal));
-        } else if (totalXp != currentTotalXp) {
-            updateTileCounter();
+        }
+
+        // Refresh metrics
+        long currentTotalXp = client.getOverallExperience();
+        if (totalXp != currentTotalXp) {
             totalXp = currentTotalXp;
         }
+        updateXpUntilNextTile();
+        updateRemainingTiles();
     }
 
     public void importGroundMarkerTiles() {
@@ -313,7 +318,7 @@ public class TilemanModePlugin extends Plugin {
                 savePoints(Integer.parseInt(region), groundMarkerTiles);
             }
         }
-        loadPoints();
+        updateTilesToRender();
     }
 
     List<String> getAllRegionIds(String configGroup) {
@@ -340,27 +345,24 @@ public class TilemanModePlugin extends Plugin {
         return getConfiguration(CONFIG_GROUP, REGION_PREFIX + regionId);
     }
 
-    private void updateTileCounter() {
+    private void updateTileCountFromConfigs() {
+        log.debug("Updating tile counter");
+
         List<String> regions = configManager.getConfigurationKeys(CONFIG_GROUP + ".region");
         int totalTiles = 0;
         for (String region : regions) {
             Collection<TilemanModeTile> regionTiles = getTiles(removeRegionPrefix(region));
-
             totalTiles += regionTiles.size();
         }
-
-        log.debug("Updating tile counter");
-
-        updateTotalTilesUsed(totalTiles);
-        updateRemainingTiles(totalTiles);
-        updateXpUntilNextTile();
+        totalTilesUsed = totalTiles;
+        updateRemainingTiles();
     }
 
     private void updateTotalTilesUsed(int totalTilesCount) {
-        totalTilesUsed = totalTilesCount;
+
     }
 
-    private void updateRemainingTiles(int placedTiles) {
+    private void updateRemainingTiles() {
         // Start with tiles offset. We always get these
         int earnedTiles = config.tilesOffset();
 
@@ -374,7 +376,7 @@ public class TilemanModePlugin extends Plugin {
             earnedTiles += client.getTotalLevel();
         }
 
-        remainingTiles = earnedTiles - placedTiles;
+        remainingTiles = earnedTiles - totalTilesUsed;
     }
 
     private void updateXpUntilNextTile() {
@@ -392,8 +394,8 @@ public class TilemanModePlugin extends Plugin {
         }.getType());
     }
 
-    private void loadPoints() {
-        points.clear();
+    private void updateTilesToRender() {
+        tilesToRender.clear();
 
         int[] regions = client.getMapRegions();
 
@@ -403,11 +405,10 @@ public class TilemanModePlugin extends Plugin {
 
         for (int regionId : regions) {
             // load points for region
-            log.debug("Loading points for region {}", regionId);
+            log.debug("Loading tiles to render for region {}", regionId);
             Collection<WorldPoint> worldPoint = translateToWorldPoint(getTiles(regionId));
-            points.addAll(worldPoint);
+            tilesToRender.addAll(worldPoint);
         }
-        updateTileCounter();
     }
 
     private void savePoints(int regionId, Collection<TilemanModeTile> points) {
@@ -621,31 +622,45 @@ public class TilemanModePlugin extends Plugin {
         updateTileMark(localPoint, true);
     }
 
-    private void updateTileMark(LocalPoint localPoint, boolean markedValue) {
+    private void updateTileMark(LocalPoint localPoint, boolean claimTile) {
+
+        // never modify a blocked tile
         if(containsAnyOf(getTileMovementFlags(localPoint), fullBlock)) {
             return;
         }
 
         WorldPoint worldPoint = WorldPoint.fromLocalInstance(client, localPoint);
-
         int regionId = worldPoint.getRegionID();
         TilemanModeTile point = new TilemanModeTile(regionId, worldPoint.getRegionX(), worldPoint.getRegionY(), client.getPlane());
         log.debug("Updating point: {} - {}", point, worldPoint);
 
         List<TilemanModeTile> tilemanModeTiles = new ArrayList<>(getTiles(regionId));
+        Boolean tileIsUnlocked = tilemanModeTiles.contains(point);
+        Boolean stateChanged = false;
 
-        if (markedValue) {
-            // Try add tile
-            if (!tilemanModeTiles.contains(point) && (config.allowTileDeficit() || remainingTiles > 0)) {
+        // attempt to unlock
+        if (claimTile && !tileIsUnlocked) {
+            if ((config.allowTileDeficit() || remainingTiles > 0)) {
                 tilemanModeTiles.add(point);
+                totalTilesUsed += 1;
+                stateChanged = true;
             }
-        } else {
-            // Try remove tile
-            tilemanModeTiles.remove(point);
         }
 
-        savePoints(regionId, tilemanModeTiles);
-        loadPoints();
+        // release lock
+        if (!claimTile && tileIsUnlocked)
+        {
+            tilemanModeTiles.remove(point);
+            totalTilesUsed -= 1;
+            stateChanged = true;
+        }
+
+        // do updates only if state changes to prevent updates when unchanged
+        if (stateChanged)
+        {
+            savePoints(regionId, tilemanModeTiles);
+            updateTilesToRender();
+        }
     }
 
     int getXpUntilNextTile() {


### PR DESCRIPTION
### What issue does this PR address?

Currently a large number of high skill point individuals "detile" at late game due to significant latency when running tile counts in the region of 45K-120K tiles (based on a few chats I've had). The primary cited cause for this is significant chug with high tile counts.

Despite not being a high tile count player (yet) out of curiousity I decided to investigate the root cause. After some brief investigation into the code base I was able to intuit the root cause of the issue and added additional logging inside the problematic method updateTileCounter();

On reasonably high end hardware, profiling revealed that even at only 2000 tiles unlocked across relatively few regions, execution times were in the realm of 0.5ms -> 1.5ms depending on sampling time (probably JVM GC?) each time the method was triggered. 

Extrapolating to ~100k tiles, that would result in spikes of 25-75ms each time the method is checked which is sufficient to drop frame times to <13fps on good hardware.

As a part of the logging I also tracked when the method was being called. The worst offender is that the method is being called every time you change tile, even if the tile is already unlocked.

I verified with a couple of online Tilemen that experienced the issue that standing still did not see the same frame time drops, only experiencing it when they moved. This helped confirm my suspicions that the updates were the primary cause of the plugin chug.

Underneath the hood, updateTileCounter was essentially reloading and reprocessing the entirety of the configuration data for the plugin every time a player moved or made a claim. this is very expensive computationally with large list dimensions, esepcially if we're also converting long strings as a part of the operation.

<hr>

### How does it address the issue

- Modifies the implementation to only parse the complete configs (computationally expensive) when it's actually needed. 
When you enter the game
When you enable the plugin
This was primarily being done only to give an accurate totalTilesSpent count.

- Modifies implementations so that 
private int totalTilesUsed, remainingTiles, xpUntilNextTile;
now more efficiently track their state without requiring updating every tile movement.

- Updates the naming of the getPoints() method to make it clear it's primarily interested in building a rendering list of tiles in the regions around the player.

- updateTileMark now more discretely handles state changes to ensure totalTilesUsed remains accurate rather than requiring a complete reevaluation every time a claim changes.

<hr>

### What testing has been performed

- [x] Unclaiming a tile works, increments totals by 1
- [x] Claiming a tile works, decrements totals by 1
- [x] Gaining xp triggers tile count updates
- [x] Moving without automark works correctly
- [x] Moving with automark works correctly
- [x] Changing regions significantly (Varrock -> walked to rimmington) all works as expected
- [x] Teleporting works as expected
- [x] Existing configs aren't impacted / visibly changed

<hr>

### Risk analysis

- Upgrading existing data format?
> Storage format and read / writing is kept identical, only thing that has changed is how we're figuring out how many tiles are claimed and keeping that number accurate.

- What happens if totalTilesUsed somehow falls out of sync?
> every login / reload reads the configs identically to how they currently do. All tile mark updates flow through updateTileMark method so it should universally capture the relevant state changes anyway.

<hr>