### PR TITLE
Fix performance problems relating to config file sizes

### DIFF
--- a/src/main/java/com/tileman/TileInfoOverlay.java
+++ b/src/main/java/com/tileman/TileInfoOverlay.java
@@ -85,6 +85,11 @@ class TileInfoOverlay extends OverlayPanel {
                 .right(unlockedTiles)
                 .build());
 
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("DIAG")
+                .right(plugin.diagPrint)
+                .build());
+
         panelComponent.setPreferredSize(new Dimension(
                 getLongestStringWidth(STRINGS, graphics)
                         + getLongestStringWidth(new String[] {unlockedTiles, unspentTiles}, graphics),

--- a/src/main/java/com/tileman/TileInfoOverlay.java
+++ b/src/main/java/com/tileman/TileInfoOverlay.java
@@ -85,11 +85,6 @@ class TileInfoOverlay extends OverlayPanel {
                 .right(unlockedTiles)
                 .build());
 
-        panelComponent.getChildren().add(LineComponent.builder()
-                .left("DIAG")
-                .right(plugin.diagPrint)
-                .build());
-
         panelComponent.setPreferredSize(new Dimension(
                 getLongestStringWidth(STRINGS, graphics)
                         + getLongestStringWidth(new String[] {unlockedTiles, unspentTiles}, graphics),

--- a/src/main/java/com/tileman/TilemanModeMinimapOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeMinimapOverlay.java
@@ -65,7 +65,7 @@ class TilemanModeMinimapOverlay extends Overlay
 			return null;
 		}
 
-		final Collection<WorldPoint> points = plugin.getPoints();
+		final Collection<WorldPoint> points = plugin.getTilesToRender();
 		for (final WorldPoint point : points)
 		{
 			WorldPoint worldPoint = point;

--- a/src/main/java/com/tileman/TilemanModeOverlay.java
+++ b/src/main/java/com/tileman/TilemanModeOverlay.java
@@ -60,7 +60,7 @@ public class TilemanModeOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		final Collection<WorldPoint> points = plugin.getPoints();
+		final Collection<WorldPoint> points = plugin.getTilesToRender();
 		for (final WorldPoint point : points)
 		{
 			if (point.getPlane() != client.getPlane())

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -131,8 +131,6 @@ public class TilemanModePlugin extends Plugin {
     private boolean inHouse = false;
     private long totalXp;
 
-    public String diagPrint = "";
-
     @Subscribe
     public void onMenuOptionClicked(MenuOptionClicked event) {
         if (event.getMenuAction().getId() != MenuAction.RUNELITE.getId() ||
@@ -348,12 +346,6 @@ public class TilemanModePlugin extends Plugin {
     Collection<TilemanModeTile> getTiles(int regionId) {
 
         List<TilemanModeTile> tiles = new ArrayList<>();
-
-        // load any declarations in the old v1 format
-        // Collection<TilemanModeTile> v1data = getConfigurationV1(CONFIG_GROUP, REGION_PREFIX + regionId);
-        // tiles.addAll(v1data);
-
-        // load declarations in the more efficient v2 format and append them
         for (int plane = 0; plane < 4; plane++) {
             Collection<TilemanModeTile> v2data = getConfigurationV2(regionId, plane);
             tiles.addAll(v2data);
@@ -372,10 +364,6 @@ public class TilemanModePlugin extends Plugin {
         }
         totalTilesUsed = totalTiles;
         updateRemainingTiles();
-    }
-
-    private void updateTotalTilesUsed(int totalTilesCount) {
-
     }
 
     private void updateRemainingTiles() {
@@ -406,7 +394,6 @@ public class TilemanModePlugin extends Plugin {
         String prefix = "tilemanMode.region_";
         List<String> v1keys = configManager.getConfigurationKeys(prefix);
         for (String key : v1keys){
-            diagPrint = key; // tilemanMode.region_57777
             Integer regionId = Integer.parseInt(key.replace(prefix, ""));
             String json = configManager.getConfiguration("tilemanMode", "region_" + regionId);
             List<TilemanModeTile> tiles = gson.fromJson(json, new TypeToken<List<TilemanModeTile>>(){}.getType());

--- a/src/main/java/com/tileman/TilemanModePlugin.java
+++ b/src/main/java/com/tileman/TilemanModePlugin.java
@@ -469,6 +469,12 @@ public class TilemanModePlugin extends Plugin {
 
     private void savePoints(int regionId, Collection<TilemanModeTile> tiles) {
 
+        // don't write empty regions. remove them instead.
+        if (tiles == null || tiles.isEmpty()) {
+            configManager.unsetConfiguration(CONFIG_GROUP, REGION_PREFIX + regionId);
+            return;
+        }
+
         int numBytes = 512; // (64x * 64y)bits / 8 bits to the byte. 64x64 because that's Runelite's region size
         byte[][] bytes = new byte[4][numBytes]; // 4 because that's the number of planes Runelite uses for maps
         Boolean[] containsData = new Boolean[4];
@@ -498,12 +504,6 @@ public class TilemanModePlugin extends Plugin {
 
             // write the bytes directly to base64 encoded string.
             configManager.setConfiguration(CONFIG_GROUP, REGION_PREFIX_V2 + regionId + "_" + i, bytes[i]);
-        }
-
-        // scrub empty regions - we do this last so any allocated tiles are saved if the plugin crashes above
-        if (tiles == null || tiles.isEmpty()) {
-            configManager.unsetConfiguration(CONFIG_GROUP, REGION_PREFIX + regionId);
-            return;
         }
 
     }


### PR DESCRIPTION
Don't consider until #49 merges as this PR builds on the changes there.

<hr>

### What issue does this PR address?

Significant latency can still be experienced when claiming tiles at high tile counts. I profiled this in #49 and on my system each write at 183k claimed tiles was taking over 40ms tied almost entirely to the single instruction writing the string to the config files. That means you still get choppy claim behavior while moving (half what it was previously, but still...)

<hr>

### How does it address the issue

This PR:
- Stores tile claim information in a vastly more efficient format inside config files
- Adds migration logic so that old tile claim configs are automatically migrated to new claim configs.

<hr>

### Technical foundations explained

Currently we store tile information as long strings in the config files

<details>
tilemanMode.region_11422=[{"regionId"\:11422,"regionX"\:22,"regionY"\:12,"z"\:0},{"regionId"\:11422,"regionX"\:22,"regionY"\:14,"z"\:0},{"regionId"\:11422,"regionX"\:22,"regionY"\:13,"z"\:0},{"regionId"\:11422,"regionX"\:23,"regionY"\:16,"z"\:0},{"regionId"\:11422,"regionX"\:22,"regionY"\:15,"z"\:0},{"regionId"\:11422,"regionX"\:25,"regionY"\:17,"z"\:0},{"regionId"\:11422,"regionX"\:24,"regionY"\:17,"z"\:0},{"regionId"\:11422,"regionX"\:21,"regionY"\:31,"z"\:0},{"regionId"\:11422,"regionX"\:21,"regionY"\:33,"z"\:0},{"regionId"\:11422,"regionX"\:21,"regionY"\:32,"z"\:0},{"regionId"\:11422,"regionX"\:22,"regionY"\:35,"z"\:0},{"regionId"\:11422,"regionX"\:21,"regionY"\:34,"z"\:0},{"regionId"\:11422,"regionX"\:23,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:25,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:24,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:27,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:26,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:29,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:28,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:31,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:30,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:33,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:32,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:35,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:34,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:37,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:36,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:38,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:40,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:39,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:42,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:41,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:44,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:43,"regionY"\:36,"z"\:0},{"regionId"\:11422,"regionX"\:45,"regionY"\:37,"z"\:0},{"regionId"\:11422,"regionX"\:44,"regionY"\:37,"z"\:0},{"regionId"\:11422,"regionX"\:47,"regionY"\:39,"z"\:0},{"regionId"\:11422,"regionX"\:46,"regionY"\:38,"z"\:0},{"regionId"\:11422,"regionX"\:49,"regionY"\:41,"z"\:0},{"regionId"\:11422,"regionX"\:48,"regionY"\:40,"z"\:0},{"regionId"\:11422,"regionX"\:50,"regionY"\:43,"z"\:0},{"regionId"\:11422,"regionX"\:50,"regionY"\:42,"z"\:0},{"regionId"\:11422,"regionX"\:50,"regionY"\:45,"z"\:0},{"regionId"\:11422,"regionX"\:50,"regionY"\:44,"z"\:0},{"regionId"\:11422,"regionX"\:52,"regionY"\:47,"z"\:0},{"regionId"\:11422,"regionX"\:51,"regionY"\:46,"z"\:0},{"regionId"\:11422,"regionX"\:52,"regionY"\:49,"z"\:0},{"regionId"\:11422,"regionX"\:52,"regionY"\:51,"z"\:0},{"regionId"\:11422,"regionX"\:52,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:50,"regionY"\:52,"z"\:0},{"regionId"\:11422,"regionX"\:51,"regionY"\:52,"z"\:0},{"regionId"\:11422,"regionX"\:50,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:50,"regionY"\:53,"z"\:0},{"regionId"\:11422,"regionX"\:48,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:49,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:46,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:47,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:44,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:45,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:42,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:43,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:40,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:41,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:38,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:39,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:36,"regionY"\:52,"z"\:0},{"regionId"\:11422,"regionX"\:37,"regionY"\:53,"z"\:0},{"regionId"\:11422,"regionX"\:34,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:35,"regionY"\:51,"z"\:0},{"regionId"\:11422,"regionX"\:32,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:33,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:30,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:31,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:28,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:29,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:26,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:27,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:24,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:25,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:22,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:23,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:20,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:21,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:18,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:19,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:17,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:14,"regionY"\:52,"z"\:0},{"regionId"\:11422,"regionX"\:15,"regionY"\:51,"z"\:0},{"regionId"\:11422,"regionX"\:12,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:13,"regionY"\:53,"z"\:0},{"regionId"\:11422,"regionX"\:10,"regionY"\:55,"z"\:0},{"regionId"\:11422,"regionX"\:11,"regionY"\:55,"z"\:0},{"regionId"\:11422,"regionX"\:9,"regionY"\:56,"z"\:0},{"regionId"\:11422,"regionX"\:20,"regionY"\:31,"z"\:0},{"regionId"\:11422,"regionX"\:52,"regionY"\:48,"z"\:0},{"regionId"\:11422,"regionX"\:16,"regionY"\:50,"z"\:0},{"regionId"\:11422,"regionX"\:8,"regionY"\:59,"z"\:0},{"regionId"\:11422,"regionX"\:8,"regionY"\:57,"z"\:0},{"regionId"\:11422,"regionX"\:8,"regionY"\:58,"z"\:0},{"regionId"\:11422,"regionX"\:37,"regionY"\:35,"z"\:0},{"regionId"\:11422,"regionX"\:47,"regionY"\:22,"z"\:0},{"regionId"\:11422,"regionX"\:15,"regionY"\:56,"z"\:0},{"regionId"\:11422,"regionX"\:14,"regionY"\:55,"z"\:0},{"regionId"\:11422,"regionX"\:13,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:15,"regionY"\:55,"z"\:0},{"regionId"\:11422,"regionX"\:15,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:14,"regionY"\:54,"z"\:0},{"regionId"\:11422,"regionX"\:14,"regionY"\:56,"z"\:0},{"regionId"\:11422,"regionX"\:13,"regionY"\:55,"z"\:0}]
</details>

Each region gains an extra 
{"regionId"\:11422,"regionX"\:14,"regionY"\:56,"z"\:0},
every time a tile is claimed.

Eventually, you end up with multimillion line config files (183k tiles = ~10.8m char config files) that are slow to operate on.

Every time you need information out of the configs, these long strings with duplicate information have to be parsed (computationally expensive) back to give a list of tiles, which involves reprocessing a lot of this redundant data such as regionID per tile.

Instead of the above, the new approach represents tile unlock information as a sequence of single bits.
0001000000010000000100001..... etc

This works because maps in runelite are implemented in blocks known as regions, 64 wide x 64 high x 4 layers deep. There are 4096 (64x64) tiles per layer per region. We provide a fixed formula for mapping from position index in the above list of bits back to the tile x and y. Using this we can now represent an entire layer of a region in only (4096 / 8) 512 bytes, and we never need to process for information, we can simply look up the correct index directly to determine if a tile is locked or unlocked.

We encode the bit sequence in the config files as a base64 string, which converts it down to something like this:
<details>
tilemanMode.regionv2_6199_1=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAgAAAAAAAAACAAAAAAAAAAIABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\=
</details>
which is now capable of representing every tile claimed in a layer of a region.

Direct lookup and no need to parse makes claiming and loading significantly faster.

### Testing performed

- [x] Automark at 330k tiles isn't lagging.
- [x] 10.8m char config file became 1.8m
- [x] Fidelity of claims verified before / after migration 
- [x] Tile claim counts the same before / after

TBC - capture existing test cases

### Risk Analysis

- TBC - Migration concerns?
- Lack of manual editability (how much is this really going on?)
- Cross plugin compatibility (need to check group tileman imports / exports, improved tile indicators etc)
