### PR TITLE
Fix plugin hub build failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,17 +13,14 @@ repositories {
 def runeLiteVersion = 'latest.release'
 
 dependencies {
-	implementation 'ch.qos.logback:logback-classic:1.5.18'
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.4'
-	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.12'
-	testImplementation 'org.slf4j:slf4j-simple:1.7.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion, {
-		exclude group: 'ch.qos.logback', module: 'logback-classic'
-	}
+	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
 group = 'com.tileman'


### PR DESCRIPTION
<hr>

### What issue does this PR address?

In #50 I modified the gradle build file in what I believed was the correct way. Ultimately this resulted in a gradle build failure when the plugin was trying to be autoamtically verified by plugin-hub.

### How does it address the issue

This PR reverts the gradle build dependency settings to match those of the example plugin that RuneLite provides in their repo for plugin developers.

Updated left / example plugin right
<img width="2258" height="381" alt="image" src="https://github.com/user-attachments/assets/981a00c3-1220-4cc2-a0d6-0fb1684bd6cf" />

https://github.com/runelite/example-plugin/blob/97436cee47107beda2f7b6520effe73b88c95d6d/build.gradle#L18-L27

<hr>

### What testing has been performed
- [x] log messages still generate and propogate back to intelliJ IDE with --debug enabled for the build environment.
- [x] plugin still compiles